### PR TITLE
Remove const enum since it's not supported by Babel

### DIFF
--- a/api/http-codes.ts
+++ b/api/http-codes.ts
@@ -1,5 +1,5 @@
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
-export const enum HttpStatus {
+export enum HttpStatus {
   // 2xx Success
   OK = 200,
   // 4xx Client Error


### PR DESCRIPTION
More info here:
https://github.com/babel/babel/issues/8741